### PR TITLE
fix macos CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,14 @@ jobs:
       - name: Bundle install
         run: bundle install
 
+      - name: Un-Install pkg-config
+        if: matrix.os == 'macos'
+        run: |
+          # pkg-config formula is deprecated but it's still installed
+          # in GitHub Actions runner now. We can remove this once
+          # pkg-config formula is removed from GitHub Actions runner.
+          brew uninstall pkg-config || :
+
       - name: Compile extension
         run: bundle exec rake compile
 
@@ -61,7 +69,7 @@ jobs:
       - name: MacOS Start XQuartz
         if: matrix.os == 'macos'
         run: |
-          open -a /Applications/Utilities/XQuartz.app
+          open -a XQuartz
           # wait some seconds until XQuartz has started
           sleep 10
 
@@ -71,3 +79,8 @@ jobs:
       - name: Linux Print logs if job failed
         if: ${{ failure() && matrix.os == 'ubuntu' }}
         run: cat ~/.xpra/*
+
+      - name: Print compile logs if failed
+        if: ${{ failure() && matrix.os != 'windows' }}
+        run: find . -name '*.log' -print0 | xargs -0 cat
+

--- a/ext/fox16_c/extconf.rb
+++ b/ext/fox16_c/extconf.rb
@@ -295,6 +295,9 @@ dir_config('fox', '/usr/local/include/fox-1.6', '/usr/local/lib')
 dir_config('fxscintilla', '/usr/local/include/fxscintilla', '/usr/local/lib')
 
 unless enable_config("win32-cross")
+  if RUBY_PLATFORM =~ /^arm64-darwin/
+    dir_config('x11', '/opt/homebrew/include', '/opt/homebrew/lib')
+  end
   checking_for "fox per pkg-config" do
     pkg_config("fox")
   end


### PR DESCRIPTION
- print build logs in case of failure
- uninstall pkg-config - it points to the x86 libraries
- Add homebrew directories for ARM64, they are necessary to find xquartz/X11 libraries.