### PR TITLE
Type of "NULL pointer" error changed in swig 4.3.0

### DIFF
--- a/test/TC_FXApp.rb
+++ b/test/TC_FXApp.rb
@@ -21,7 +21,8 @@ class TC_FXApp2 < Fox::TestCase
   end
 
   def test_nil_window_raises_argument_error
-    assert_raise(ArgumentError){ app.runPopup(nil) }
+    err = assert_raise{ app.runPopup(nil) }
+    assert_match(/NULL pointer/, err.to_s)
   end
 
   def check_events(pipe_rd, pipe_wr)

--- a/test/TC_FXButton.rb
+++ b/test/TC_FXButton.rb
@@ -11,7 +11,8 @@ class TC_FXButton < Fox::TestCase
   end
 
   def test_nil_parent_raises_argument_error
-    assert_raise(ArgumentError){ FXButton.new(nil, "buttonText") }
+    err = assert_raise{ FXButton.new(nil, "buttonText") }
+    assert_match(/NULL pointer/, err.to_s)
   end
 
   def testText

--- a/test/TC_FXDialogBox.rb
+++ b/test/TC_FXDialogBox.rb
@@ -5,8 +5,9 @@ class TC_FXDialogBox < Test::Unit::TestCase
   include Fox
 
   def test_nil_app_raises_argument_error
-    assert_raise ArgumentError do
+    err = assert_raise do
       FXDialogBox.new(nil, "title")
     end
+    assert_match(/NULL pointer/, err.to_s)
   end
 end

--- a/test/TC_FXGLViewer.rb
+++ b/test/TC_FXGLViewer.rb
@@ -23,7 +23,8 @@ class TC_FXGLViewer < Fox::TestCase
   end
 
   def test_nil_app_raises_argument_error
-    assert_raise(ArgumentError){ FXGLVisual.supported?(nil) }
+    err = assert_raise{ FXGLVisual.supported?(nil) }
+    assert_match(/NULL pointer/, err.to_s)
   end
 
 =begin

--- a/test/TC_FXMainWindow.rb
+++ b/test/TC_FXMainWindow.rb
@@ -5,9 +5,10 @@ class TC_FXMainWindow < Test::Unit::TestCase
   include Fox
 
   def test_nil_app_raises_argument_error
-    assert_raise ArgumentError do
+    err = assert_raise do
       FXMainWindow.new(nil, "title")
     end
+    assert_match(/NULL pointer/, err.to_s)
   end
 
   def test_non_created_app_raises_runtime_error

--- a/test/TC_FXMessageBox.rb
+++ b/test/TC_FXMessageBox.rb
@@ -10,7 +10,8 @@ class TC_FXMessageBox < Fox::TestCase
   end
 
   def test_nil_app_raises_argument_error
-    assert_raise(ArgumentError){ FXMessageBox.new(nil, "Save?", "Save?", :opts => MBOX_SAVE_CANCEL_DONTSAVE) }
+    err = assert_raise{ FXMessageBox.new(nil, "Save?", "Save?", :opts => MBOX_SAVE_CANCEL_DONTSAVE) }
+    assert_match(/NULL pointer/, err.to_s)
   end
 
   def test_construct_with_save_cancel_dontsave

--- a/test/TC_FXScrollArea.rb
+++ b/test/TC_FXScrollArea.rb
@@ -11,7 +11,8 @@ class TC_FXScrollArea < Fox::TestCase
   end
 
   def test_nil_parent_raises_argument_error
-    assert_raise(ArgumentError){ FXScrollArea.new(nil) }
+    err = assert_raise{ FXScrollArea.new(nil) }
+    assert_match(/NULL pointer/, err.to_s)
   end
 
   def test_position_get

--- a/test/TC_FXShell.rb
+++ b/test/TC_FXShell.rb
@@ -16,7 +16,8 @@ class TC_FXShell < Test::Unit::TestCase
   end
 
   def test_nil_parent_raises_argument_error
-    assert_raise(ArgumentError){ FXShell.new(nil, 0, 0, 0, 0, 0) }
+    err = assert_raise{ FXShell.new(nil, 0, 0, 0, 0, 0) }
+    assert_match(/NULL pointer/, err.to_s)
   end
 
   def test_new


### PR DESCRIPTION
It was ArgumentError before and is NullReferenceError now. Change in commit https://github.com/swig/swig/commit/9bf4842002b34e11a310a9691bd07c2e1ec6df94

Since the error text kept the same, we don't test for the class now, but for the text.